### PR TITLE
ensure we return an array when calling for liked tweets

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ use UtxoOne\TwitterUltimatePhp\Clients\UserClient;
 $client = new UserClient(bearerToken: $_ENV['TWITTER_BEARER_TOKEN']);
 
 $user = $client->getUserByUsername('utxoone');
-$likedTweets = $client->getLikedTweets($user->getId());
+$likedTweets = $client->getLikedTweets($user->getId())->all();
 
 foreach ($likedTweets as $likedTweet) {
   $likedTweet->getId();


### PR DESCRIPTION
The docs seems to be wrong. 

without the `->all()`, when dumping `$likedTweet` its still an array and not an actual Tweet object. 